### PR TITLE
Add header to request and parse xml response properly

### DIFF
--- a/public/app/jobs/jobs.controller.js
+++ b/public/app/jobs/jobs.controller.js
@@ -121,10 +121,18 @@
 
                     $http({
                         method: "GET",
-                        url: "/proxy?url=pz-jobmanager.cf.piazzageo.io/job/status"
+                        url: "/proxy?url=pz-jobmanager.cf.piazzageo.io/job/status",
+                        headers: {
+                            Accept: "application/xml"
+                        }
                         //url: "/proxy?url=" + result.data.host + "/job/status"
                     }).then(function successCallback( html ) {
-                        $scope.jobStatuses = html.data;
+                        var d = jQuery.parseXML(html.data);
+                        $scope.jobStatuses = [];
+                        var childNodes = d.childNodes[0].childNodes;
+                        for (var i = 0; i < childNodes.length; i++) {
+                            $scope.jobStatuses.push(childNodes[i].textContent)
+                        }
                         $scope.jobStatuses.push("All");
                     }, function errorCallback(response){
                         console.log("search.controller fail");


### PR DESCRIPTION
Needed to add an Accept header because it's returning xml instead of json. This fixed the 502 Bad Gateway error.  Then we needed to parse the xml to get the list of strings.