### PR TITLE
Replace hard coded ? with variable

### DIFF
--- a/public/nginx.conf
+++ b/public/nginx.conf
@@ -48,7 +48,7 @@ http {
 
       location ~ "^/proxy/(.*)" {
           resolver 8.8.8.8;
-          proxy_pass https://$1?$query_string;
+          proxy_pass https://$1$is_args$query_string;
       }
 
       location /proxy {


### PR DESCRIPTION
is_args displays a ? when there are parameters and empty string otherwise