### PR TITLE
3441 Quick fix for state issues

### DIFF
--- a/public/treeview.js
+++ b/public/treeview.js
@@ -268,12 +268,12 @@
           })
           // just for authenticated
           .state('index',{
-              url : '/',
+              url : '/index',
               templateUrl : '/index.html',
-              data : {requireLogin : true },
+              data : {requireLogin : true }
           });
 
-      $urlRouterProvider.otherwise("/login");
+      $urlRouterProvider.otherwise("login");
   });
 
 
@@ -296,10 +296,12 @@
             // authenticated previously
             if (Auth.isLoggedIn) {
                 var shouldGoToIndex = fromState.name === ""
-                    && toState.name !== "index";
+                    && toState.name !== "login";
+                    // Used to be index, but that caused problems with tabs && toState.name !== "index";
 
                 if (shouldGoToIndex) {
-                    $state.go('index');
+                    // Used to be index, but that caused problems with tabs $state.go('index');
+                    $state.go('login');
                     event.preventDefault();
                 }
                 return;


### PR DESCRIPTION
This is a quick fix for the login/tab/file uploader bug.  I'd like to revisit this in the near future...

It seems as though trying to use $state AND bootstraps built-in tab system causes it to continue to try to switch "states" when a tab is clicked (they use the same url notation /#/stateName).  No tabs work when we're in the "index" state so this fix forces the app into the "login" state.

I'd like to fix this a little better soon, but it works for now.